### PR TITLE
Refactor sidebars into reusable components

### DIFF
--- a/admin/absen/barcode_umum.php
+++ b/admin/absen/barcode_umum.php
@@ -58,88 +58,12 @@ $barcodeLabels = [
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="../index.php">
-                    <div>
-                        <img src="../../assets/img/madep.png" alt="logo" width="40px">
-                        <span class="brand-text">Absensi</span>
-                    </div>
-                </a>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item">
-                    <a class="nav-link" href="../index.php">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-
-                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Kelola Data</span>
-                    </a>
-                    <div id="booking" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../siswa/index.php">Siswa</a>
-                            <a class="collapse-item" href="../akun/index.php">Admin</a>
-                            <a class="collapse-item" href="../akun_siswa/index.php">Report Harian Masuk</a>
-                            <a class="collapse-item" href="../akun_siswa/pulang.php">Report Harian Pulang</a>
-                            <a class="collapse-item" href="../guru/index.php">Menu guru</a>
-                            <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item active">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-receipt"></i>
-                        <span>Absensi</span>
-                    </a>
-                    <div id="data" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="input.php">Masuk</a>
-                            <a class="collapse-item" href="input_plg.php">Pulang</a>
-                            <a class="collapse-item active" href="barcode_umum.php">Barcode Masuk/Pulang</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Data Absensi</span>
-                    </a>
-                    <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="data_absen.php">Data Tidak Hadir</a>
-                            <a class="collapse-item" href="data_masuk.php">Data Absen Masuk</a>
-                            <a class="collapse-item" href="data_pulang.php">Data Absen Pulang</a>
-                        </div>
-                    </div>
-                </li>
-
-
-                <hr class="sidebar-divider d-none d-md-block">
-
-                <li class="nav-item">
-                    <a class="nav-link" href="../../logout.php">
-                        <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                        <span>Logout</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'barcode';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/absen/data.php
+++ b/admin/absen/data.php
@@ -43,92 +43,12 @@ $sekarang=date("Y-m-d");
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="../index.php">
-                <div>
-                    <img src="../../assets/img/madep.png" alt="logo" width="40px">
-                    <span class="brand-text">Absensi</span>
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../siswa/index.php">Siswa</a>
-                        <a class="collapse-item" href="../akun/index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Report Harian</a>
-                        <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="input.php">Masuk</a>
-                        <a class="collapse-item" href="input_plg.php">Pulang</a>
-                        <a class="collapse-item" href="barcode_umum.php">Barcode Masuk/Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item active" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'data_tidak_hadir';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/absen/data_absen.php
+++ b/admin/absen/data_absen.php
@@ -43,94 +43,12 @@ $sekarang=date("Y-m-d");
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="../index.php">
-                <div>
-                    <img src="../../assets/img/madep.png" alt="logo" width="40px">
-                    <span class="brand-text">Absensi</span>
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../siswa/index.php">Siswa</a>
-                        <a class="collapse-item" href="../akun/index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Report Harian Masuk</a>
-                        <a class="collapse-item" href="../akun_siswa/pulang.php">Report Harian Pulang</a>
-                        <a class="collapse-item" href="../guru/index.php">Menu guru</a>
-                        <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="input.php">Masuk</a>
-                        <a class="collapse-item" href="input_plg.php">Pulang</a>
-                        <a class="collapse-item" href="barcode_umum.php">Barcode Masuk/Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item active" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'data_tidak_hadir';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/absen/data_masuk.php
+++ b/admin/absen/data_masuk.php
@@ -54,95 +54,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="../index.php">
-                <div>
-                    <img src="../../assets/img/madep.png" alt="logo" width="40px">
-                    <span class="brand-text">Absensi</span>
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../siswa/index.php">Siswa</a>
-                        <a class="collapse-item" href="../akun/index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Report Harian Masuk</a>
-                        <a class="collapse-item" href="../akun_siswa/pulang.php">Report Harian Pulang</a>
-                        <a class="collapse-item" href="../guru/index.php">Menu guru</a>
-                        <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="input.php">Masuk</a>
-                        <a class="collapse-item" href="input_plg.php">Pulang</a>
-                        <a class="collapse-item" href="barcode_umum.php">Barcode Masuk/Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item active" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'data_absen_masuk';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/absen/data_pulang.php
+++ b/admin/absen/data_pulang.php
@@ -46,94 +46,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="../index.php">
-                <div>
-                    <img src="../../assets/img/madep.png" alt="logo" width="40px">
-                    <span class="brand-text">Absensi</span>
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../siswa/index.php">Siswa</a>
-                        <a class="collapse-item" href="../akun/index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Report Harian Masuk</a>
-                        <a class="collapse-item" href="../akun_siswa/pulang.php">Report Harian Pulang</a>
-                        <a class="collapse-item" href="../guru/index.php">Menu guru</a>
-                        <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="input.php">Masuk</a>
-                        <a class="collapse-item" href="input_plg.php">Pulang</a>
-                        <a class="collapse-item" href="barcode_umum.php">Barcode Masuk/Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item active" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'data_absen_pulang';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/absen/input.php
+++ b/admin/absen/input.php
@@ -69,89 +69,12 @@ if (!isset($_SESSION['username'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="../index.php">
-                    <div>
-                        <img src="../../assets/img/madep.png" alt="logo" width="40px">
-                        <span class="brand-text">Absensi</span>
-                    </div>
-                </a>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item">
-                    <a class="nav-link" href="../index.php">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-
-                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Kelola Data</span>
-                    </a>
-                    <div id="booking" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../siswa/index.php">Siswa</a>
-                            <a class="collapse-item" href="../akun/index.php">Admin</a>
-                            <a class="collapse-item" href="../akun_siswa/index.php">Report Harian Masuk</a>
-                        <a class="collapse-item" href="../akun_siswa/pulang.php">Report Harian Pulang</a>
-                            <a class="collapse-item" href="../guru/index.php">Menu guru</a>
-                            <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item active">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-receipt"></i>
-                        <span>Absensi</span>
-                    </a>
-                    <div id="data" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item active" href="input.php">Masuk</a>
-                            <a class="collapse-item" href="input_plg.php">Pulang</a>
-                            <a class="collapse-item" href="barcode_umum.php">Barcode Masuk/Pulang</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Data Absensi</span>
-                    </a>
-                    <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                            <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                            <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                        </div>
-                    </div>
-                </li>
-
-        
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-                <li class="nav-item">
-                    <a class="nav-link" href="../../logout.php">
-                        <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                        <span>Logout</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'absen_masuk';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/absen/input_plg.php
+++ b/admin/absen/input_plg.php
@@ -69,89 +69,12 @@ if (!isset($_SESSION['username'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="../index.php">
-                    <div>
-                        <img src="../../assets/img/madep.png" alt="logo" width="40px">
-                        <span class="brand-text">Absensi</span>
-                    </div>
-                </a>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item">
-                    <a class="nav-link" href="../index.php">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-
-                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Kelola Data</span>
-                    </a>
-                    <div id="booking" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../siswa/index.php">Siswa</a>
-                            <a class="collapse-item" href="../akun/index.php">Admin</a>
-                            <a class="collapse-item" href="../akun_siswa/index.php">Report Harian Masuk</a>
-                            <a class="collapse-item" href="../akun_siswa/pulang.php">Report Harian Pulang</a>
-                            <a class="collapse-item" href="../guru/index.php">Menu guru</a>
-                            <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item active">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-receipt"></i>
-                        <span>Absensi</span>
-                    </a>
-                    <div id="data" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="input.php">Masuk</a>
-                            <a class="collapse-item active" href="input_plg.php">Pulang</a>
-                            <a class="collapse-item" href="barcode_umum.php">Barcode Masuk/Pulang</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Data Absensi</span>
-                    </a>
-                    <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                            <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                            <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                        </div>
-                    </div>
-                </li>
-
-                
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-                <li class="nav-item">
-                    <a class="nav-link" href="../../logout.php">
-                        <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                        <span>Logout</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'absen_pulang';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/absen/validator.php
+++ b/admin/absen/validator.php
@@ -86,97 +86,12 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                <div>
-
-                <img src="../../assets/img/madep.png" alt="logo" width="45px">
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../siswa/index.php">Siswa</a>
-                        <a class="collapse-item" href="../akun/index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Akun Siswa</a>
-                        <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item active" href="input.php">Masuk</a>
-                        <a class="collapse-item" href="input_plg.php">Pulang</a>
-                        <a class="collapse-item" href="barcode_umum.php">Barcode Masuk/Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="absen/data_absen.php">Data Absen</a>
-                        <a class="collapse-item" href="absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-            <!-- Sidebar Toggler (Sidebar) -->
-            <div class="text-center d-none d-md-inline">
-                <button class="rounded-circle border-0" id="sidebarToggle"></button>
-            </div>
-
-
-
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'absen_masuk';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/absen/validator_plg.php
+++ b/admin/absen/validator_plg.php
@@ -85,97 +85,12 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                <div>
-
-                <img src="../../assets/img/madep.png" alt="logo" width="45px">
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../siswa/index.php">Siswa</a>
-                        <a class="collapse-item" href="../akun/index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Akun Siswa</a>
-                        <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="input.php">Masuk</a>
-                        <a class="collapse-item active" href="input_plg.php">Pulang</a>
-                        <a class="collapse-item" href="barcode_umum.php">Barcode Masuk/Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="absen/data_absen.php">Data Absen</a>
-                        <a class="collapse-item" href="absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-            <!-- Sidebar Toggler (Sidebar) -->
-            <div class="text-center d-none d-md-inline">
-                <button class="rounded-circle border-0" id="sidebarToggle"></button>
-            </div>
-
-
-
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'absen_pulang';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/akun/edit.php
+++ b/admin/akun/edit.php
@@ -60,97 +60,14 @@ if (!isset($_SESSION['username'])) {
   <!-- Page Wrapper -->
   <div id="wrapper">
 
-    <!-- Sidebar -->
-    <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-
-      <!-- Sidebar - Brand -->
-      <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-        <div>
-          <img src="../../assets/img/madep.png" alt="logo" width="45px">
-        </div>
-
-      </a>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider my-0">
-
-      <!-- Nav Item - Dashboard -->
-      <li class="nav-item">
-        <a class="nav-link" href="../index.php">
-          <i class="fas fa-fw fa-tachometer-alt"></i>
-          <span>Dashboard</span></a>
-      </li>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider">
-
-
-
-      <!-- Nav Item - Pages Collapse Menu -->
-      <li class="nav-item active">
-        <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-          <i class="fas fa-fw fa-table"></i>
-          <span>Kelola Data</span>
-        </a>
-        <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-          <div class="bg-white py-2 collapse-inner rounded">
-            <a class="collapse-item " href="../siswa/index.php">Siswa</a>
-            <a class="collapse-item active" href="index.php">Admin</a>
-            <a class="collapse-item" href="../akun_siswa/index.php">Report Harian</a>
-            <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-          </div>
-        </div>
-      </li>
-      <hr class="sidebar-divider">
-      <li class="nav-item">
-        <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-          <i class="fas fa-fw fa-receipt"></i>
-          <span>Absensi</span>
-        </a>
-        <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-          <div class="bg-white py-2 collapse-inner rounded">
-            <a class="collapse-item" href="../absen/input.php">Masuk</a>
-            <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-            <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-          </div>
-        </div>
-      </li>
-      <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                    <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-      <!-- Divider -->
-      <hr class="sidebar-divider d-none d-md-block">
-
-
-      <li class="nav-item">
-        <a class="nav-link" href="../../logout.php">
-          <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-          <span>Logout</span></a>
-      </li>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider d-none d-md-block">
-
-      <!-- Sidebar Toggler (Sidebar) -->
-      <div class="text-center d-none d-md-inline">
-        <button class="rounded-circle border-0" id="sidebarToggle"></button>
-      </div>
-
-
-
-    </ul>
-    <!-- End of Sidebar -->
+            <!-- Sidebar -->
+        <?php
+        $sidebarCurrentPage = 'admin';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
+        <!-- End of Sidebar -->
 
     <!-- Content Wrapper -->
     <div id="content-wrapper" class="d-flex flex-column">

--- a/admin/akun/index.php
+++ b/admin/akun/index.php
@@ -50,95 +50,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                <div>
-               <img src="../../assets/img/madep.png" alt="logo" width="40px">
-               <span class="brand-text">Absensi</span>
-                </div>
-               
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-        
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item " href="../siswa/index.php">Siswa</a>
-                        <a class="collapse-item active" href="index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Report Harian Masuk</a>
-                        <a class="collapse-item" href="../akun_siswa/pulang.php">Report Harian Pulang</a>
-                        <a class="collapse-item" href="../guru/index.php">Menu Guru</a>
-                        <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/input.php">Masuk</a>
-                        <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-                        <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-           
-            
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'admin';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/akun_siswa/bulanan.php
+++ b/admin/akun_siswa/bulanan.php
@@ -48,94 +48,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                    <div>
-                        <img src="../../assets/img/madep.png" alt="logo" width="40px">
-                        <span class="brand-text">Absensi</span>
-                    </div>
-
-                </a>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item">
-                    <a class="nav-link" href="../index.php">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-
-
-
-                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Kelola Data</span>
-                    </a>
-                    <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item " href="../siswa/index.php">Siswa</a>
-                            <a class="collapse-item " href="../akun/index.php">Admin</a>
-                            <a class="collapse-item active" href="../akun_siswa/index.php">Report Harian</a>
-                            <a class="collapse-item" href="../guru/index.php">Menu guru</a>
-                            <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-receipt"></i>
-                        <span>Absensi</span>
-                    </a>
-                    <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../absen/input.php">Masuk</a>
-                            <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-                            <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Data Absensi</span>
-                    </a>
-                    <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                            <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                            <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                        </div>
-                    </div>
-                </li>
-
-
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-
-
-                <li class="nav-item">
-                    <a class="nav-link" href="../../logout.php">
-                        <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                        <span>Logout</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'report_bulanan';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/akun_siswa/edit.php
+++ b/admin/akun_siswa/edit.php
@@ -60,96 +60,14 @@ if (!isset($_SESSION['nama'])) {
   <!-- Page Wrapper -->
   <div id="wrapper">
 
-    <!-- Sidebar -->
-    <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-
-      <!-- Sidebar - Brand -->
-      <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-        <div>
-          <img src="../../assets/img/madep.png" alt="logo" width="45px">
-        </div>
-
-      </a>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider my-0">
-
-      <!-- Nav Item - Dashboard -->
-      <li class="nav-item">
-        <a class="nav-link" href="../index.php">
-          <i class="fas fa-fw fa-tachometer-alt"></i>
-          <span>Dashboard</span></a>
-      </li>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider">
-
-
-
-      <!-- Nav Item - Pages Collapse Menu -->
-      <li class="nav-item active">
-        <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-          <i class="fas fa-fw fa-table"></i>
-          <span>Kelola Data</span>
-        </a>
-        <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-          <div class="bg-white py-2 collapse-inner rounded">
-            <a class="collapse-item " href="../siswa/index.php">Siswa</a>
-            <a class="collapse-item" href="../akun/index">Admin</a>
-            <a class="collapse-item active" href="index.php">Akun Siswa</a>
-            <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-          </div>
-        </div>
-      </li>
-      <hr class="sidebar-divider">
-      <li class="nav-item">
-        <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-          <i class="fas fa-fw fa-receipt"></i>
-          <span>Absensi</span>
-        </a>
-        <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-          <div class="bg-white py-2 collapse-inner rounded">
-            <a class="collapse-item" href="../absen/input.php">Masuk</a>
-            <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-            <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-          </div>
-        </div>
-      </li>
-      <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-      <!-- Divider -->
-      <hr class="sidebar-divider d-none d-md-block">
-
-
-      <li class="nav-item">
-        <a class="nav-link" href="../../logout.php">
-          <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-          <span>Logout</span></a>
-      </li>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider d-none d-md-block">
-
-      <!-- Sidebar Toggler (Sidebar) -->
-      <div class="text-center d-none d-md-inline">
-        <button class="rounded-circle border-0" id="sidebarToggle"></button>
-      </div>
-
-
-
-    </ul>
-    <!-- End of Sidebar -->
+            <!-- Sidebar -->
+        <?php
+        $sidebarCurrentPage = 'report_masuk';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
+        <!-- End of Sidebar -->
 
     <!-- Content Wrapper -->
     <div id="content-wrapper" class="d-flex flex-column">

--- a/admin/akun_siswa/index.php
+++ b/admin/akun_siswa/index.php
@@ -48,94 +48,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                    <div>
-                        <img src="../../assets/img/madep.png" alt="logo" width="40px">
-                        <span class="brand-text">Absensi</span>
-                    </div>
-
-                </a>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item">
-                    <a class="nav-link" href="../index.php">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-
-
-
-                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Kelola Data</span>
-                    </a>
-                    <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item " href="../siswa/index.php">Siswa</a>
-                            <a class="collapse-item " href="../akun/index.php">Admin</a>
-                            <a class="collapse-item active" href="../akun_siswa/index.php">Report absen</a>
-                            <a class="collapse-item" href="../guru/index.php">Menu guru</a>
-                            <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-receipt"></i>
-                        <span>Absensi</span>
-                    </a>
-                    <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../absen/input.php">Masuk</a>
-                            <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-                            <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Data Absensi</span>
-                    </a>
-                    <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                            <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                            <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                        </div>
-                    </div>
-                </li>
-
-
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-
-
-                <li class="nav-item">
-                    <a class="nav-link" href="../../logout.php">
-                        <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                        <span>Logout</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'report_masuk';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/akun_siswa/pulang.php
+++ b/admin/akun_siswa/pulang.php
@@ -48,95 +48,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                    <div>
-                        <img src="../../assets/img/madep.png" alt="logo" width="40px">
-                        <span class="brand-text">Absensi</span>
-                    </div>
-
-                </a>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item">
-                    <a class="nav-link" href="../index.php">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-
-
-
-                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Kelola Data</span>
-                    </a>
-                    <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item " href="../siswa/index.php">Siswa</a>
-                            <a class="collapse-item " href="../akun/index.php">Admin</a>
-                            <a class="collapse-item" href="../akun_siswa/index.php">Report Harian Masuk</a>
-                            <a class="collapse-item active" href="../akun_siswa/pulang.php">Report Harian Pulang</a>
-                            <a class="collapse-item" href="../guru/index.php">Menu guru</a>
-                            <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-receipt"></i>
-                        <span>Absensi</span>
-                    </a>
-                    <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../absen/input.php">Masuk</a>
-                            <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-                            <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Data Absensi</span>
-                    </a>
-                    <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                            <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                            <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                        </div>
-                    </div>
-                </li>
-
-
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-
-
-                <li class="nav-item">
-                    <a class="nav-link" href="../../logout.php">
-                        <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                        <span>Logout</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'report_pulang';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/guru/edit.php
+++ b/admin/guru/edit.php
@@ -60,98 +60,14 @@ if (!isset($_SESSION['username'])) {
   <!-- Page Wrapper -->
   <div id="wrapper">
 
-    <!-- Sidebar -->
-    <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-
-      <!-- Sidebar - Brand -->
-      <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-        <div>
-          <img src="../../assets/img/madep.png" alt="logo" width="45px">
-        </div>
-
-      </a>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider my-0">
-
-      <!-- Nav Item - Dashboard -->
-      <li class="nav-item">
-        <a class="nav-link" href="../index.php">
-          <i class="fas fa-fw fa-tachometer-alt"></i>
-          <span>Dashboard</span></a>
-      </li>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider">
-
-
-
-      <!-- Nav Item - Pages Collapse Menu -->
-      <li class="nav-item active">
-        <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-          <i class="fas fa-fw fa-table"></i>
-          <span>Kelola Data</span>
-        </a>
-        <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-          <div class="bg-white py-2 collapse-inner rounded">
-            <a class="collapse-item " href="../siswa/index.php">Siswa</a>
-            <a class="collapse-item" href="index.php">Admin</a>
-            <a class="collapse-item" href="../akun_siswa/index.php">Report Harian</a>
-            <a class="collapse-item active" href="../akun_siswa/index.php">Menu guru</a>
-            <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-          </div>
-        </div>
-      </li>
-      <hr class="sidebar-divider">
-      <li class="nav-item">
-        <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-          <i class="fas fa-fw fa-receipt"></i>
-          <span>Absensi</span>
-        </a>
-        <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-          <div class="bg-white py-2 collapse-inner rounded">
-            <a class="collapse-item" href="../absen/input.php">Masuk</a>
-            <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-            <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-          </div>
-        </div>
-      </li>
-      <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                    <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-      <!-- Divider -->
-      <hr class="sidebar-divider d-none d-md-block">
-
-
-      <li class="nav-item">
-        <a class="nav-link" href="../../logout.php">
-          <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-          <span>Logout</span></a>
-      </li>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider d-none d-md-block">
-
-      <!-- Sidebar Toggler (Sidebar) -->
-      <div class="text-center d-none d-md-inline">
-        <button class="rounded-circle border-0" id="sidebarToggle"></button>
-      </div>
-
-
-
-    </ul>
-    <!-- End of Sidebar -->
+            <!-- Sidebar -->
+        <?php
+        $sidebarCurrentPage = 'guru';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
+        <!-- End of Sidebar -->
 
     <!-- Content Wrapper -->
     <div id="content-wrapper" class="d-flex flex-column">

--- a/admin/guru/index.php
+++ b/admin/guru/index.php
@@ -50,95 +50,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                <div>
-               <img src="../../assets/img/madep.png" alt="logo" width="40px">
-               <span class="brand-text">Absensi</span>
-                </div>
-               
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-        
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item " href="../siswa/index.php">Siswa</a>
-                        <a class="collapse-item" href="index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Report Harian Masuk</a>
-                        <a class="collapse-item" href="../akun_siswa/pulang.php">Report Harian Pulang</a>
-                        <a class="collapse-item active" href="../guru/index.php">Menu guru</a>
-                        <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/input.php">Masuk</a>
-                        <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-                        <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-           
-            
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'guru';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/index.php
+++ b/admin/index.php
@@ -45,94 +45,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                <div>
-               <img src="../assets/img/madep.png" alt="logo" width="40px">
-               <span class="brand-text">Absensi</span>
-                </div>
-               
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item active">
-                <a class="nav-link" href="index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-        
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="siswa/index.php">Siswa</a>
-                        <a class="collapse-item" href="akun/index.php">Admin</a>
-                        <a class="collapse-item" href="akun_siswa/index.php">Report Harian Masuk</a>
-                        <a class="collapse-item" href="akun_siswa/pulang.php">Report Harian Pulang</a>
-                        <a class="collapse-item" href="guru/index.php">Menu guru</a>
-                        <a class="collapse-item" href="orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                    <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="absen/input.php">Masuk</a>
-                            <a class="collapse-item" href="absen/input_plg.php">Pulang</a>
-                            <a class="collapse-item" href="absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-                        </div>
-                    </div>
-                </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-            <hr class="sidebar-divider d-none d-md-block">
-
-            <li class="nav-item">
-                <a class="nav-link" href="../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-            
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'dashboard';
+        $sidebarRootPath = '../';
+        $sidebarAdminPath = '';
+        include __DIR__ . '/sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/indexs.php
+++ b/admin/indexs.php
@@ -40,94 +40,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                <div>
-               <img src="../assets/img/madep.png" alt="logo" width="40px">
-               <span class="brand-text">Absensi</span>
-                </div>
-               
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item active">
-                <a class="nav-link" href="index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-        
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="siswa/index.php">Siswa</a>
-                        <a class="collapse-item" href="akun/index.php">Admin</a>
-                        <a class="collapse-item" href="akun_siswa/index.php">Report Harian Masuk</a>
-                        <a class="collapse-item" href="akun_siswa/pulang.php">Report Harian Pulang</a>
-                        <a class="collapse-item" href="guru/index.php">Menu guru</a>
-                        <a class="collapse-item" href="orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                    <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="absen/input.php">Masuk</a>
-                            <a class="collapse-item" href="absen/input_plg.php">Pulang</a>
-                            <a class="collapse-item" href="absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-                        </div>
-                    </div>
-                </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-            <hr class="sidebar-divider d-none d-md-block">
-
-            <li class="nav-item">
-                <a class="nav-link" href="../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-            
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'dashboard';
+        $sidebarRootPath = '../';
+        $sidebarAdminPath = '';
+        include __DIR__ . '/sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/orang_tua/edit.php
+++ b/admin/orang_tua/edit.php
@@ -87,99 +87,14 @@ while ($row = mysqli_fetch_assoc($siswaQuery)) {
   <!-- Page Wrapper -->
   <div id="wrapper">
 
-    <!-- Sidebar -->
-    <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-
-      <!-- Sidebar - Brand -->
-      <a class="sidebar-brand d-flex align-items-center justify-content-center" href="../index.php">
-        <div>
-          <img src="../../assets/img/madep.png" alt="logo" width="45px">
-        </div>
-
-      </a>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider my-0">
-
-      <!-- Nav Item - Dashboard -->
-      <li class="nav-item">
-        <a class="nav-link" href="../index.php">
-          <i class="fas fa-fw fa-tachometer-alt"></i>
-          <span>Dashboard</span></a>
-      </li>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider">
-
-
-
-      <!-- Nav Item - Pages Collapse Menu -->
-      <li class="nav-item active">
-        <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-          <i class="fas fa-fw fa-table"></i>
-          <span>Kelola Data</span>
-        </a>
-        <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-          <div class="bg-white py-2 collapse-inner rounded">
-            <a class="collapse-item" href="../siswa/index.php">Siswa</a>
-            <a class="collapse-item" href="../akun/index.php">Admin</a>
-            <a class="collapse-item" href="../akun_siswa/index.php">Report Harian Masuk</a>
-            <a class="collapse-item" href="../akun_siswa/pulang.php">Report Harian Pulang</a>
-            <a class="collapse-item" href="../guru/index.php">Menu guru</a>
-            <a class="collapse-item active" href="index.php">Orang Tua</a>
-          </div>
-        </div>
-      </li>
-      <hr class="sidebar-divider">
-      <li class="nav-item">
-        <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-          <i class="fas fa-fw fa-receipt"></i>
-          <span>Absensi</span>
-        </a>
-        <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-          <div class="bg-white py-2 collapse-inner rounded">
-            <a class="collapse-item" href="../absen/input.php">Masuk</a>
-            <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-            <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-          </div>
-        </div>
-      </li>
-      <hr class="sidebar-divider">
-      <li class="nav-item">
-        <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-          <i class="fas fa-fw fa-table"></i>
-          <span>Data Absensi</span>
-        </a>
-        <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-          <div class="bg-white py-2 collapse-inner rounded">
-            <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-            <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-            <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-          </div>
-        </div>
-      </li>
-      <!-- Divider -->
-      <hr class="sidebar-divider d-none d-md-block">
-
-
-      <li class="nav-item">
-        <a class="nav-link" href="../../logout.php">
-          <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-          <span>Logout</span></a>
-      </li>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider d-none d-md-block">
-
-      <!-- Sidebar Toggler (Sidebar) -->
-      <div class="text-center d-none d-md-inline">
-        <button class="rounded-circle border-0" id="sidebarToggle"></button>
-      </div>
-
-
-
-    </ul>
-    <!-- End of Sidebar -->
+            <!-- Sidebar -->
+        <?php
+        $sidebarCurrentPage = 'orang_tua';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
+        <!-- End of Sidebar -->
 
     <!-- Content Wrapper -->
     <div id="content-wrapper" class="d-flex flex-column">

--- a/admin/orang_tua/index.php
+++ b/admin/orang_tua/index.php
@@ -74,93 +74,12 @@ while ($row = mysqli_fetch_assoc($siswaQuery)) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="../index.php">
-                <div>
-               <img src="../../assets/img/madep.png" alt="logo" width="40px">
-               <span class="brand-text">Absensi</span>
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../siswa/index.php">Siswa</a>
-                        <a class="collapse-item" href="../akun/index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Report Harian Masuk</a>
-                        <a class="collapse-item" href="../akun_siswa/pulang.php">Report Harian Pulang</a>
-                        <a class="collapse-item" href="../guru/index.php">Menu guru</a>
-                        <a class="collapse-item active" href="index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                    <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../absen/input.php">Masuk</a>
-                            <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-                            <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-                        </div>
-                    </div>
-                </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-            <hr class="sidebar-divider d-none d-md-block">
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'orang_tua';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/admin/sidebar.php
+++ b/admin/sidebar.php
@@ -1,0 +1,116 @@
+<?php
+$sidebarCurrentPage = $sidebarCurrentPage ?? '';
+$sidebarRootPath = $sidebarRootPath ?? '../';
+$sidebarAdminPath = $sidebarAdminPath ?? '';
+
+if (!function_exists('adminSidebarActive')) {
+    function adminSidebarActive(string $current, array $targets): string
+    {
+        return in_array($current, $targets, true) ? 'active' : '';
+    }
+}
+
+if (!function_exists('adminSidebarShow')) {
+    function adminSidebarShow(string $current, array $targets): string
+    {
+        return in_array($current, $targets, true) ? 'show' : '';
+    }
+}
+
+$kelolaTargets = ['siswa', 'admin', 'report_masuk', 'report_pulang', 'guru', 'orang_tua', 'report_bulanan'];
+$absensiTargets = ['absen_masuk', 'absen_pulang', 'barcode'];
+$dataAbsensiTargets = ['data_tidak_hadir', 'data_absen_masuk', 'data_absen_pulang'];
+?>
+<ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
+    <div class="sticky-top">
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="<?= $sidebarAdminPath ?>index.php">
+            <div>
+                <img src="<?= $sidebarRootPath ?>assets/img/madep.png" alt="logo" width="40px">
+                <span class="brand-text">Absensi</span>
+            </div>
+        </a>
+
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0">
+
+        <!-- Nav Item - Dashboard -->
+        <li class="nav-item <?= adminSidebarActive($sidebarCurrentPage, ['dashboard']) ?>">
+            <a class="nav-link" href="<?= $sidebarAdminPath ?>index.php">
+                <i class="fas fa-fw fa-tachometer-alt"></i>
+                <span>Dashboard</span></a>
+        </li>
+
+        <!-- Divider -->
+        <hr class="sidebar-divider">
+
+        <!-- Nav Item - Kelola Data -->
+        <li class="nav-item <?= adminSidebarActive($sidebarCurrentPage, $kelolaTargets) ?>">
+            <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true"
+                aria-controls="booking">
+                <i class="fas fa-fw fa-table"></i>
+                <span>Kelola Data</span>
+            </a>
+            <div id="booking" class="collapse <?= adminSidebarShow($sidebarCurrentPage, $kelolaTargets) ?>"
+                aria-labelledby="headingTwo" data-parent="#accordionSidebar">
+                <div class="bg-white py-2 collapse-inner rounded">
+                    <a class="collapse-item <?= adminSidebarActive($sidebarCurrentPage, ['siswa']) ?>" href="<?= $sidebarAdminPath ?>siswa/index.php">Siswa</a>
+                    <a class="collapse-item <?= adminSidebarActive($sidebarCurrentPage, ['admin']) ?>" href="<?= $sidebarAdminPath ?>akun/index.php">Admin</a>
+                    <a class="collapse-item <?= adminSidebarActive($sidebarCurrentPage, ['report_masuk']) ?>" href="<?= $sidebarAdminPath ?>akun_siswa/index.php">Report Harian Masuk</a>
+                    <a class="collapse-item <?= adminSidebarActive($sidebarCurrentPage, ['report_pulang']) ?>" href="<?= $sidebarAdminPath ?>akun_siswa/pulang.php">Report Harian Pulang</a>
+                    <a class="collapse-item <?= adminSidebarActive($sidebarCurrentPage, ['guru']) ?>" href="<?= $sidebarAdminPath ?>guru/index.php">Menu guru</a>
+                    <a class="collapse-item <?= adminSidebarActive($sidebarCurrentPage, ['orang_tua']) ?>" href="<?= $sidebarAdminPath ?>orang_tua/index.php">Orang Tua</a>
+                </div>
+            </div>
+        </li>
+
+        <hr class="sidebar-divider">
+
+        <!-- Nav Item - Absensi -->
+        <li class="nav-item <?= adminSidebarActive($sidebarCurrentPage, $absensiTargets) ?>">
+            <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true"
+                aria-controls="data">
+                <i class="fas fa-fw fa-receipt"></i>
+                <span>Absensi</span>
+            </a>
+            <div id="data" class="collapse <?= adminSidebarShow($sidebarCurrentPage, $absensiTargets) ?>"
+                aria-labelledby="headingTwo" data-parent="#accordionSidebar">
+                <div class="bg-white py-2 collapse-inner rounded">
+                    <a class="collapse-item <?= adminSidebarActive($sidebarCurrentPage, ['absen_masuk']) ?>" href="<?= $sidebarAdminPath ?>absen/input.php">Masuk</a>
+                    <a class="collapse-item <?= adminSidebarActive($sidebarCurrentPage, ['absen_pulang']) ?>" href="<?= $sidebarAdminPath ?>absen/input_plg.php">Pulang</a>
+                    <a class="collapse-item <?= adminSidebarActive($sidebarCurrentPage, ['barcode']) ?>" href="<?= $sidebarAdminPath ?>absen/barcode_umum.php">Barcode Masuk/Pulang</a>
+                </div>
+            </div>
+        </li>
+        <hr class="sidebar-divider">
+
+        <!-- Nav Item - Data Absensi -->
+        <li class="nav-item <?= adminSidebarActive($sidebarCurrentPage, $dataAbsensiTargets) ?>">
+            <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true"
+                aria-controls="data2">
+                <i class="fas fa-fw fa-table"></i>
+                <span>Data Absensi</span>
+            </a>
+            <div id="data2" class="collapse <?= adminSidebarShow($sidebarCurrentPage, $dataAbsensiTargets) ?>"
+                aria-labelledby="headingTwo" data-parent="#accordionSidebar">
+                <div class="bg-white py-2 collapse-inner rounded">
+                    <a class="collapse-item <?= adminSidebarActive($sidebarCurrentPage, ['data_tidak_hadir']) ?>" href="<?= $sidebarAdminPath ?>absen/data_absen.php">Data Tidak Hadir</a>
+                    <a class="collapse-item <?= adminSidebarActive($sidebarCurrentPage, ['data_absen_masuk']) ?>" href="<?= $sidebarAdminPath ?>absen/data_masuk.php">Data Absen Masuk</a>
+                    <a class="collapse-item <?= adminSidebarActive($sidebarCurrentPage, ['data_absen_pulang']) ?>" href="<?= $sidebarAdminPath ?>absen/data_pulang.php">Data Absen Pulang</a>
+                </div>
+            </div>
+        </li>
+
+        <hr class="sidebar-divider d-none d-md-block">
+
+        <li class="nav-item">
+            <a class="nav-link" href="<?= $sidebarRootPath ?>logout.php">
+                <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
+                <span>Logout</span></a>
+        </li>
+
+        <!-- Divider -->
+        <hr class="sidebar-divider d-none d-md-block">
+
+    </div>
+</ul>

--- a/admin/siswa/barcode.php
+++ b/admin/siswa/barcode.php
@@ -142,98 +142,13 @@ if (isset($_SESSION['sebagai'])) {
     <!-- Page Wrapper -->
   <div id="wrapper">
 
-<!-- Sidebar -->
-<ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top"> 
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                <div>
-               <img src="../../assets/img/madep.png" alt="logo" width="40px">
-               <span class="brand-text">Absensi</span>
-                </div>
-               
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-        
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item active" href="index.php">Siswa</a>
-                        <a class="collapse-item" href="../akun/index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Report Harian</a>
-                        <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/input.php">Masuk</a>
-                        <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-                        <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-
-            
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-            
-
-        
-          </div>
-        </ul>
+        <!-- Sidebar -->
+        <?php
+        $sidebarCurrentPage = 'siswa';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
 <!-- Content Wrapper -->

--- a/admin/siswa/detail.php
+++ b/admin/siswa/detail.php
@@ -70,98 +70,13 @@ if (isset($_SESSION['sebagai'])) {
   <!-- Page Wrapper -->
   <div id="wrapper">
 
-    <!-- Sidebar -->
-    <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top"> 
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                <div>
-               <img src="../../assets/img/madep.png" alt="logo" width="40px">
-               <span class="brand-text">Absensi</span>
-                </div>
-               
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-        
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item active" href="index.php">Siswa</a>
-                        <a class="collapse-item" href="../akun/index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Report Harian</a>
-                        <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/input.php">Masuk</a>
-                        <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-                        <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-
-            
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-            
-
-        
-          </div>
-        </ul>
+            <!-- Sidebar -->
+        <?php
+        $sidebarCurrentPage = 'siswa';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
     <!-- Content Wrapper -->

--- a/admin/siswa/edit.php
+++ b/admin/siswa/edit.php
@@ -65,98 +65,13 @@ if (!isset($_SESSION['username'])) {
   <!-- Page Wrapper -->
   <div id="wrapper">
 
-    <!-- Sidebar -->
-    <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                <div>
-               <img src="../../assets/img/madep.png" alt="logo" width="40px">
-               <span class="brand-text">Absensi</span>
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item active" href="index.php">Siswa</a>
-                        <a class="collapse-item" href="../akun/index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Report Harian</a>
-                        <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../absen/input.php">Masuk</a>
-                            <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-                            <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-
-
-          </div>
-        </ul>
+            <!-- Sidebar -->
+        <?php
+        $sidebarCurrentPage = 'siswa';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
     <!-- Content Wrapper -->

--- a/admin/siswa/index.php
+++ b/admin/siswa/index.php
@@ -48,97 +48,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                    <div>
-                        <img src="../../assets/img/madep.png" alt="logo" width="40px">
-                        <span class="brand-text">Absensi</span>
-                    </div>
-
-                </a>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider my-0">
-
-                <!-- Nav Item - Dashboard -->
-                <li class="nav-item">
-                    <a class="nav-link" href="../index.php">
-                        <i class="fas fa-fw fa-tachometer-alt"></i>
-                        <span>Dashboard</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-
-
-
-                <!-- Nav Item - Pages Collapse Menu -->
-                <li class="nav-item active">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Kelola Data</span>
-                    </a>
-                    <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item active" href="index.php">Siswa</a>
-                            <a class="collapse-item" href="../akun/index.php">Admin</a>
-                            <a class="collapse-item" href="../akun_siswa/index.php">Report Harian Masuk</a>
-                            <a class="collapse-item" href="../akun_siswa/pulang.php">Report Harian Pulang</a>
-                            <a class="collapse-item" href="../guru/index.php">Menu guru</a>
-                            <a class="collapse-item" href="../orang_tua/index.php">Orang Tua</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-receipt"></i>
-                        <span>Absensi</span>
-                    </a>
-                    <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../absen/input.php">Masuk</a>
-                            <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-                            <a class="collapse-item" href="../absen/barcode_umum.php">Barcode Masuk/Pulang</a>
-                        </div>
-                    </div>
-                </li>
-                <hr class="sidebar-divider">
-                <li class="nav-item">
-                    <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                        <i class="fas fa-fw fa-table"></i>
-                        <span>Data Absensi</span>
-                    </a>
-                    <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                        <div class="bg-white py-2 collapse-inner rounded">
-                            <a class="collapse-item" href="../absen/data_absen.php">Data Tidak Hadir</a>
-                            <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                            <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                        </div>
-                    </div>
-                </li>
-
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-
-
-                <li class="nav-item">
-                    <a class="nav-link" href="../../logout.php">
-                        <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                        <span>Logout</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-
-
-
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'siswa';
+        $sidebarRootPath = '../../';
+        $sidebarAdminPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/user/akun_siswa/edit.php
+++ b/user/akun_siswa/edit.php
@@ -60,94 +60,14 @@ if (!isset($_SESSION['nama'])) {
   <!-- Page Wrapper -->
   <div id="wrapper">
 
-    <!-- Sidebar -->
-    <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-
-      <!-- Sidebar - Brand -->
-      <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-        <div>
-          <img src="../../assets/img/madep.png" alt="logo" width="45px">
-        </div>
-
-      </a>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider my-0">
-
-      <!-- Nav Item - Dashboard -->
-      <li class="nav-item">
-        <a class="nav-link" href="../index.php">
-          <i class="fas fa-fw fa-tachometer-alt"></i>
-          <span>Dashboard</span></a>
-      </li>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider">
-
-
-
-      <!-- Nav Item - Pages Collapse Menu -->
-      <li class="nav-item active">
-        <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-          <i class="fas fa-fw fa-table"></i>
-          <span>Kelola Data</span>
-        </a>
-        <div id="booking" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-          <div class="bg-white py-2 collapse-inner rounded">
-            <a class="collapse-item " href="../siswa/index.php">Siswa</a>
-            <a class="collapse-item" href="../akun/index">Admin</a>
-            <a class="collapse-item active" href="index.php">Akun Siswa</a>
-          </div>
-        </div>
-      </li>
-      <hr class="sidebar-divider">
-      <li class="nav-item">
-        <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-          <i class="fas fa-fw fa-receipt"></i>
-          <span>Absensi</span>
-        </a>
-        <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-          <div class="bg-white py-2 collapse-inner rounded">
-            <a class="collapse-item" href="../absen/input.php">Masuk</a>
-            <a class="collapse-item" href="../absen/input_plg.php">Pulang</a>
-          </div>
-        </div>
-      </li>
-      <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="../absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-      <!-- Divider -->
-      <hr class="sidebar-divider d-none d-md-block">
-
-
-      <li class="nav-item">
-        <a class="nav-link" href="../../logout.php">
-          <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-          <span>Logout</span></a>
-      </li>
-
-      <!-- Divider -->
-      <hr class="sidebar-divider d-none d-md-block">
-
-      <!-- Sidebar Toggler (Sidebar) -->
-      <div class="text-center d-none d-md-inline">
-        <button class="rounded-circle border-0" id="sidebarToggle"></button>
-      </div>
-
-
-
-    </ul>
-    <!-- End of Sidebar -->
+            <!-- Sidebar -->
+        <?php
+        $sidebarCurrentPage = 'report_harian';
+        $sidebarRootPath = '../../';
+        $sidebarUserPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
+        <!-- End of Sidebar -->
 
     <!-- Content Wrapper -->
     <div id="content-wrapper" class="d-flex flex-column">

--- a/user/akun_siswa/index.php
+++ b/user/akun_siswa/index.php
@@ -42,61 +42,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-                <!-- Sidebar - Brand -->
-                <a class="sidebar-brand d-flex align-items-center justify-content-center" href="#">
-                    <div>
-                        <img src="../../assets/img/madep.png" alt="logo" width="40px">
-                        <span class="brand-text">Absensi</span>
-                    </div>
-
-                </a>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../index.php">Masuk</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item active" href="akun_siswa/index.php">Report Harian</a>
-                    </div>
-                </div>
-            </li>
-
-
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-
-
-                <li class="nav-item">
-                    <a class="nav-link" href="../../logout.php">
-                        <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                        <span>Logout</span></a>
-                </li>
-
-                <!-- Divider -->
-                <hr class="sidebar-divider d-none d-md-block">
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'report_harian';
+        $sidebarRootPath = '../../';
+        $sidebarUserPath = '../';
+        include __DIR__ . '/../sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/user/data_masuk.php
+++ b/user/data_masuk.php
@@ -42,72 +42,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="#">
-                <div>
-                    <img src="../assets/img/madep.png" alt="logo" width="40px">
-                    <span class="brand-text">Absensi</span>
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-           
-
-            <!-- Divider -->
-           
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-          
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="index.php">Masuk</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item active" href="data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="akun_siswa/index.php">Report Harian</a>
-                    </div>
-                </div>
-            </li>
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'data_absen_masuk';
+        $sidebarRootPath = '../';
+        $sidebarUserPath = '';
+        include __DIR__ . '/sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/user/data_pulang.php
+++ b/user/data_pulang.php
@@ -42,72 +42,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="#">
-                <div>
-                    <img src="../assets/img/madep.png" alt="logo" width="40px">
-                    <span class="brand-text">Absensi</span>
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-
-            <!-- Divider -->
-        
-            <!-- Nav Item - Pages Collapse Menu -->
-            
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="index.php">Masuk</a>
-                        <a class="collapse-item" href="input_plg.php">Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item active" href="data_pulang.php">Data Absen Pulang</a>
-                        <a class="collapse-item" href="akun_siswa/index.php">Report Harian</a>
-                    </div>
-                </div>
-            </li>
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'data_absen_pulang';
+        $sidebarRootPath = '../';
+        $sidebarUserPath = '';
+        include __DIR__ . '/sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/user/index.php
+++ b/user/index.php
@@ -77,62 +77,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="#">
-                <div>
-                    <img src="../assets/img/madep.png" alt="logo" width="40px">
-                    <span class="brand-text">Absensi</span>
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-        
-            <!-- Divider -->
-
-
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item active" href="index.php">Masuk</a>
-                        <a class="collapse-item " href="input_plg.php">Pulang</a>
-
-                    </div>
-                </div>
-            </li>
-           
-         
-
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-            
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'absen_masuk';
+        $sidebarRootPath = '../';
+        $sidebarUserPath = '';
+        include __DIR__ . '/sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/user/input_plg.php
+++ b/user/input_plg.php
@@ -77,58 +77,12 @@ if (isset($_SESSION['sebagai'])) {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-            <div class="sticky-top">
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="../index.php">
-                <div>
-                    <img src="../assets/img/madep.png" alt="logo" width="40px">
-                    <span class="brand-text">Absensi</span>
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <!-- Nav Item - Dashboard -->
-         
-            <!-- Divider -->
-            <!-- Nav Item - Pages Collapse Menu -->
-            
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item " href="index.php">Masuk</a>
-                        <a class="collapse-item active" href="input_plg.php">Pulang</a>
-
-                    </div>
-                </div>
-            </li>
-        
-           
-
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-            
-            </div>
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'absen_pulang';
+        $sidebarRootPath = '../';
+        $sidebarUserPath = '';
+        include __DIR__ . '/sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/user/sidebar.php
+++ b/user/sidebar.php
@@ -1,0 +1,83 @@
+<?php
+$sidebarCurrentPage = $sidebarCurrentPage ?? '';
+$sidebarRootPath = $sidebarRootPath ?? '../';
+$sidebarUserPath = $sidebarUserPath ?? '';
+
+if (!function_exists('userSidebarActive')) {
+    function userSidebarActive(string $current, array $targets): string
+    {
+        return in_array($current, $targets, true) ? 'active' : '';
+    }
+}
+
+if (!function_exists('userSidebarShow')) {
+    function userSidebarShow(string $current, array $targets): string
+    {
+        return in_array($current, $targets, true) ? 'show' : '';
+    }
+}
+
+$absensiTargets = ['absen_masuk', 'absen_pulang'];
+$dataAbsensiTargets = ['data_absen_masuk', 'data_absen_pulang', 'report_harian'];
+?>
+<ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
+    <div class="sticky-top">
+        <!-- Sidebar - Brand -->
+        <a class="sidebar-brand d-flex align-items-center justify-content-center" href="#">
+            <div>
+                <img src="<?= $sidebarRootPath ?>assets/img/madep.png" alt="logo" width="40px">
+                <span class="brand-text">Absensi</span>
+            </div>
+        </a>
+
+        <!-- Divider -->
+        <hr class="sidebar-divider my-0">
+
+        <!-- Divider -->
+        <hr class="sidebar-divider">
+        <li class="nav-item <?= userSidebarActive($sidebarCurrentPage, $absensiTargets) ?>">
+            <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true"
+                aria-controls="data">
+                <i class="fas fa-fw fa-receipt"></i>
+                <span>Absensi</span>
+            </a>
+            <div id="data" class="collapse <?= userSidebarShow($sidebarCurrentPage, $absensiTargets) ?>"
+                aria-labelledby="headingTwo" data-parent="#accordionSidebar">
+                <div class="bg-white py-2 collapse-inner rounded">
+                    <a class="collapse-item <?= userSidebarActive($sidebarCurrentPage, ['absen_masuk']) ?>" href="<?= $sidebarUserPath ?>index.php">Masuk</a>
+                    <a class="collapse-item <?= userSidebarActive($sidebarCurrentPage, ['absen_pulang']) ?>" href="<?= $sidebarUserPath ?>input_plg.php">Pulang</a>
+                </div>
+            </div>
+        </li>
+
+        <hr class="sidebar-divider">
+        <li class="nav-item <?= userSidebarActive($sidebarCurrentPage, $dataAbsensiTargets) ?>">
+            <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true"
+                aria-controls="data2">
+                <i class="fas fa-fw fa-table"></i>
+                <span>Data Absensi</span>
+            </a>
+            <div id="data2" class="collapse <?= userSidebarShow($sidebarCurrentPage, $dataAbsensiTargets) ?>"
+                aria-labelledby="headingTwo" data-parent="#accordionSidebar">
+                <div class="bg-white py-2 collapse-inner rounded">
+                    <a class="collapse-item <?= userSidebarActive($sidebarCurrentPage, ['data_absen_masuk']) ?>" href="<?= $sidebarUserPath ?>data_masuk.php">Data Absen Masuk</a>
+                    <a class="collapse-item <?= userSidebarActive($sidebarCurrentPage, ['data_absen_pulang']) ?>" href="<?= $sidebarUserPath ?>data_pulang.php">Data Absen Pulang</a>
+                    <a class="collapse-item <?= userSidebarActive($sidebarCurrentPage, ['report_harian']) ?>" href="<?= $sidebarUserPath ?>akun_siswa/index.php">Report Harian</a>
+                </div>
+            </div>
+        </li>
+
+        <!-- Divider -->
+        <hr class="sidebar-divider d-none d-md-block">
+
+        <li class="nav-item">
+            <a class="nav-link" href="<?= $sidebarRootPath ?>logout.php">
+                <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
+                <span>Logout</span></a>
+        </li>
+
+        <!-- Divider -->
+        <hr class="sidebar-divider d-none d-md-block">
+
+    </div>
+</ul>

--- a/user/validator.php
+++ b/user/validator.php
@@ -86,95 +86,12 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                <div>
-
-                <img src="../../assets/img/madep.png" alt="logo" width="45px">
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#booking" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Kelola Data</span>
-                </a>
-                <div id="booking" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="../siswa/index.php">Siswa</a>
-                        <a class="collapse-item" href="../akun/index.php">Admin</a>
-                        <a class="collapse-item" href="../akun_siswa/index.php">Akun Siswa</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item active" href="index.php">Masuk</a>
-                        <a class="collapse-item" href="input_plg.php">Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="absen/data_absen.php">Data Absen</a>
-                        <a class="collapse-item" href="absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-            <!-- Sidebar Toggler (Sidebar) -->
-            <div class="text-center d-none d-md-inline">
-                <button class="rounded-circle border-0" id="sidebarToggle"></button>
-            </div>
-
-
-
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'absen_masuk';
+        $sidebarRootPath = '../';
+        $sidebarUserPath = '';
+        include __DIR__ . '/sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->

--- a/user/validator_plg.php
+++ b/user/validator_plg.php
@@ -85,82 +85,12 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     <div id="wrapper">
 
         <!-- Sidebar -->
-        <ul class="navbar-nav bg-gradient-primary sidebar sidebar-dark accordion" id="accordionSidebar">
-
-            <!-- Sidebar - Brand -->
-            <a class="sidebar-brand d-flex align-items-center justify-content-center" href="index.php">
-                <div>
-
-                <img src="../assets/img/madep.png" alt="logo" width="45px">
-                </div>
-
-            </a>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider my-0">
-
-            <!-- Nav Item - Dashboard -->
-            <li class="nav-item">
-                <a class="nav-link" href="../index.php">
-                    <i class="fas fa-fw fa-tachometer-alt"></i>
-                    <span>Dashboard</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider">
-
-            <!-- Nav Item - Pages Collapse Menu -->
-            <hr class="sidebar-divider">
-            <li class="nav-item active">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-receipt"></i>
-                    <span>Absensi</span>
-                </a>
-                <div id="data" class="collapse show" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="index.php">Masuk</a>
-                        <a class="collapse-item active" href="input_plg.php">Pulang</a>
-                    </div>
-                </div>
-            </li>
-            <hr class="sidebar-divider">
-            <li class="nav-item">
-                <a class="nav-link collapsed" href="#" data-toggle="collapse" data-target="#data2" aria-expanded="true" aria-controls="collapseTwo">
-                    <i class="fas fa-fw fa-table"></i>
-                    <span>Data Absensi</span>
-                </a>
-                <div id="data2" class="collapse" aria-labelledby="headingTwo" data-parent="#accordionSidebar">
-                    <div class="bg-white py-2 collapse-inner rounded">
-                        <a class="collapse-item" href="absen/data_absen.php">Data Absen</a>
-                        <a class="collapse-item" href="absen/data_masuk.php">Data Absen Masuk</a>
-                        <a class="collapse-item" href="absen/data_pulang.php">Data Absen Pulang</a>
-                    </div>
-                </div>
-            </li>
-
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-
-
-            <li class="nav-item">
-                <a class="nav-link" href="../../logout.php">
-                    <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray"></i>
-                    <span>Logout</span></a>
-            </li>
-
-            <!-- Divider -->
-            <hr class="sidebar-divider d-none d-md-block">
-
-            <!-- Sidebar Toggler (Sidebar) -->
-            <div class="text-center d-none d-md-inline">
-                <button class="rounded-circle border-0" id="sidebarToggle"></button>
-            </div>
-
-
-
-        </ul>
+        <?php
+        $sidebarCurrentPage = 'absen_pulang';
+        $sidebarRootPath = '../';
+        $sidebarUserPath = '';
+        include __DIR__ . '/sidebar.php';
+        ?>
         <!-- End of Sidebar -->
 
         <!-- Content Wrapper -->


### PR DESCRIPTION
## Summary
- extract shared sidebar components for admin and user sections
- update all admin-facing pages to load the new sidebar component with contextual active states
- update all user-facing pages to use the shared sidebar for consistent navigation management

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693175dbaabc832ebf42eb5108522317)